### PR TITLE
Use ifftnd instead of fftnd on PDL versions 2.006_04 and higher. Fixes #2

### DIFF
--- a/lib/PDL/DSP/mkwindows.not_a_perl_suffix
+++ b/lib/PDL/DSP/mkwindows.not_a_perl_suffix
@@ -545,7 +545,12 @@ $window_definitions{chebyshev} = {
         my $arg = PI/$N * sequence($N);
         my $cw_im = $cw * sin($arg);
         $cw *= cos($arg);
-        PDL::FFT::fftnd($cw,$cw_im);
+        if ($PDL::VERSION < 2.006_04) {
+          PDL::FFT::fftnd($cw,$cw_im);
+        }
+        else {
+          PDL::FFT::ifftnd($cw,$cw_im);
+        }
         $M1 = $N/2;
         $M = $M1-1;
         $pos = 1;


### PR DESCRIPTION
See the description of the problem in issue #2. 
